### PR TITLE
remove 'height' from default props

### DIFF
--- a/src/editor/index.jsx
+++ b/src/editor/index.jsx
@@ -27,8 +27,7 @@ class MdEditor extends React.Component {
 
   static defaultProps = {
     placeholder: '请输入内容...',
-    lineNum: true,
-    height: '600px'
+    lineNum: true
   }
 
   componentDidMount() {


### PR DESCRIPTION
![qq 20190201154250](https://user-images.githubusercontent.com/13071103/52109325-0f67dd80-2638-11e9-82c8-96d06e18fd10.png)

#### Short
the 'height' inside props overlays the 'height' in class '.for-fullscreen'

#### Detail
`props`里的`{ height: '600px' }` 会使`fullscreen`无法真正全屏。因为`props`里的`height`直接加在元素上，优先级太高，覆盖了`.for-fullscreen`里的`height: 100%;`，`.for-container`里已经包含了`height: 600px;`，无需重复设置默认高度。

如果考虑自定义高度的话，要么考虑从自定义options读取height，要么考虑其他方式实现fullscreen。