### PR TITLE
fix line number problem

### DIFF
--- a/src/editor/index.jsx
+++ b/src/editor/index.jsx
@@ -45,6 +45,12 @@ class MdEditor extends React.Component {
     }
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.value !== this.props.value) {
+      this.handleLineIndex(nextProps.value)
+    }
+  }
+
   // 输入框改变
   handleChange = e => {
     const value = e.target.value


### PR DESCRIPTION
#### problem
外部改变`<Editor value={someValue} />`的value时，行号不会自动变化。

#### 复现方法
在[demo](https://md.kkfor.com/)中打开React Dev Tool，手动改变`MdEditor`的`props.value`，增加几个`\n`，行号不会增加。  
*Note:* 实在找不到合适的预览方式，codepen中不知如何引入`for-editor`。